### PR TITLE
Allow build.fingerprint to be larger [1/2]

### DIFF
--- a/tools/post_process_props.py
+++ b/tools/post_process_props.py
@@ -30,7 +30,7 @@ def iteritems(obj):
 # The constants in system_properties.h includes the termination NUL,
 # so we decrease the values by 1 here.
 PROP_NAME_MAX = 31
-PROP_VALUE_MAX = 91
+PROP_VALUE_MAX = 95
 
 # Put the modifications that you need to make into the /system/build.prop into this
 # function. The prop object has get(name) and put(name,value) methods.


### PR DESCRIPTION
build.fingerprint is only allowed to be 91 bytes, this brings it up to 95 bytes

Change-Id: I0bd4dd49e05358b2662a00c1fddb35dac008e5c5
