### PR TITLE
Revert "Allow build.fingerprint to be larger [1/2]"

### DIFF
--- a/tools/post_process_props.py
+++ b/tools/post_process_props.py
@@ -30,7 +30,7 @@ def iteritems(obj):
 # The constants in system_properties.h includes the termination NUL,
 # so we decrease the values by 1 here.
 PROP_NAME_MAX = 31
-PROP_VALUE_MAX = 95
+PROP_VALUE_MAX = 91
 
 # Put the modifications that you need to make into the /system/build.prop into this
 # function. The prop object has get(name) and put(name,value) methods.


### PR DESCRIPTION
This reverts commit 78b03c73f15c2336a4d21213ed0b30b4afabf7ca.

Change-Id: I1a268a383dd85d2ad7853699d1998be7eaa87b5e
